### PR TITLE
Load service variables from .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   database:
     image: "zulip/zulip-postgresql:14"
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       POSTGRES_DB: "zulip"
       POSTGRES_USER: "zulip"
@@ -14,6 +16,8 @@ services:
   memcached:
     image: "memcached:alpine"
     restart: unless-stopped
+    env_file:
+      - .env
     command:
       - "sh"
       - "-euc"
@@ -29,6 +33,8 @@ services:
   rabbitmq:
     image: "rabbitmq:4.0.7"
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       RABBITMQ_DEFAULT_USER: "zulip"
       RABBITMQ_DEFAULT_PASS: "REPLACE_WITH_SECURE_RABBITMQ_PASSWORD"
@@ -37,6 +43,8 @@ services:
   redis:
     image: "redis:alpine"
     restart: unless-stopped
+    env_file:
+      - .env
     command:
       - "sh"
       - "-euc"
@@ -50,6 +58,8 @@ services:
   zulip:
     image: "zulip/docker-zulip:10.3-0"
     restart: unless-stopped
+    env_file:
+      - .env
     build:
       context: .
       args:


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in all services

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a67f943a8832dabfa7ddcdf66c2ad