### PR TITLE
Add LDAP variables in Kubernetes manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ instructions.
 A Kubernetes pod file is in the `kubernetes/` folder; you can run it
 with `kubectl create -f ./kubernetes/`.
 
+Secret values in the manifest must be base64-encoded.  For example,
+the `auth-ldap-bind-password` entry in `zulip-secrets` should contain
+the base64 representation of your LDAP bind password.
+
 You should read the `docker-compose` section above to understand how
 this works, since it's a very similar setup. You'll want to clone
 this repository, edit the `zulip-rc.yml` to configure the image, etc.

--- a/kubernetes/zulip-deploy-secure.yaml
+++ b/kubernetes/zulip-deploy-secure.yaml
@@ -24,6 +24,8 @@ data:
   rabbitmq-password: cmFiYml0bXE=
   redis-password: cmVkaXM=
   zulip-secret-key: enVsaXA=
+  # Must be base64-encoded
+  auth-ldap-bind-password: <base64-password>
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -420,6 +422,22 @@ spec:
               value: "zulip.d2-india.com"
             - name: SETTING_ZULIP_ADMINISTRATOR
               value: "balajidegalas@gmail.com"
+            # LDAP authentication
+            - name: SETTING_AUTH_LDAP_SERVER_URI
+              value: ldap://ldap.example.com
+            - name: SETTING_AUTH_LDAP_BIND_DN
+              value: CN=binduser,OU=Users,DC=example,DC=com
+            - name: SECRETS_auth_ldap_bind_password
+              valueFrom:
+                secretKeyRef:
+                  name: zulip-secrets
+                  key: auth-ldap-bind-password
+            - name: SETTING_AUTH_LDAP_USER_SEARCH
+              value: >
+                LDAPSearch("OU=Users,DC=example,DC=com",
+                           ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)")
+            - name: ZULIP_AUTH_BACKENDS
+              value: 'EmailAuthBackend,ZulipLDAPAuthBackend'
           ports:
             - containerPort: 80
             - containerPort: 443


### PR DESCRIPTION
## Summary
- extend `zulip-secrets` with an LDAP bind password secret
- configure LDAP environment variables for the Zulip container
- document Kubernetes secret encoding requirement

## Testing
- `git diff --staged --name-only`


------
https://chatgpt.com/codex/tasks/task_e_684a75d557bc832d8ae96a89162e26b8